### PR TITLE
fix(typings): re-export WindowFeaturesOptions for further usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,3 +52,4 @@ function popupCentered(
 }
 
 export default popupCentered
+export { WindowFeaturesOptions }


### PR DESCRIPTION
This PR should allow the following usage:
```ts
import popupCentered, { WindowFeaturesOptions } from 'popup-centered';

const options: WindowFeaturesOptions = { ... };
popupCentered('popup.html', 'Centered Popup', options);
```